### PR TITLE
Make a new request after 50k results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,4 @@ rsa-key
 tags
 singer-check-tap-data
 state.json
+target.json

--- a/tap_helpshift/client.py
+++ b/tap_helpshift/client.py
@@ -257,7 +257,7 @@ class HelpshiftAPI:
             # order, we can start a new request at page 1 using the last
             # updated_at time we saw.
             if next_page * get_args['page-size'] > MAX_PAGE_SIZE:
-                LOGGER.info(f'helpshift query exceeded {next_page} pages, starting loop over')
+                LOGGER.info(f'helpshift query exceeded {next_page-1} pages, starting loop over')
                 next_page = 1
                 get_args['updated_since'] = max_synced
 

--- a/tap_helpshift/client.py
+++ b/tap_helpshift/client.py
@@ -239,6 +239,7 @@ class HelpshiftAPI:
         assert False, 'unreachable'
 
     async def paging_get(self, url, results_key, replication_key=None, **get_args):
+        MAX_PAGE_SIZE = 50000
         next_page = 1
         total_returned = 0
         max_synced = None
@@ -251,12 +252,12 @@ class HelpshiftAPI:
             get_args['page-size'] = 1000
 
         while next_page:
-            # Helpshift returns a 400 error when the number of issues
+            # Helpshift returns a 400 error when the number of results
             # requested exceeds 50000. Because records are returned in asc
             # order, we can start a new request at page 1 using the last
             # updated_at time we saw.
-            if next_page > 500 and results_key == 'issues':
-                LOGGER.info('helpshift query exceeded 500 pages, starting loop over')
+            if next_page * get_args['page-size'] > MAX_PAGE_SIZE:
+                LOGGER.info(f'helpshift query exceeded {next_page} pages, starting loop over')
                 next_page = 1
                 get_args['updated_since'] = max_synced
 

--- a/tap_helpshift/client.py
+++ b/tap_helpshift/client.py
@@ -256,7 +256,7 @@ class HelpshiftAPI:
             # requested exceeds 50000. Because records are returned in asc
             # order, we can start a new request at page 1 using the last
             # updated_at time we saw.
-            if next_page * get_args['page-size'] > MAX_PAGE_SIZE:
+            if next_page > MAX_PAGE_SIZE / get_args['page-size']:
                 LOGGER.info(f'helpshift query exceeded {next_page-1} pages, starting loop over')
                 next_page = 1
                 get_args['updated_since'] = max_synced

--- a/tap_helpshift/client.py
+++ b/tap_helpshift/client.py
@@ -239,7 +239,7 @@ class HelpshiftAPI:
         assert False, 'unreachable'
 
     async def paging_get(self, url, results_key, replication_key=None, **get_args):
-        MAX_PAGE_SIZE = 50000
+        MAX_NUM_RESULTS = 50000
         next_page = 1
         total_returned = 0
         max_synced = None
@@ -256,7 +256,7 @@ class HelpshiftAPI:
             # requested exceeds 50000. Because records are returned in asc
             # order, we can start a new request at page 1 using the last
             # updated_at time we saw.
-            if next_page > MAX_PAGE_SIZE / get_args['page-size']:
+            if next_page > MAX_NUM_RESULTS / get_args['page-size']:
                 LOGGER.info(f'helpshift query exceeded {next_page-1} pages, starting loop over')
                 next_page = 1
                 get_args['updated_since'] = max_synced


### PR DESCRIPTION
All requests have a max page size of 50k based on their docs, so update to use the max page size.

https://developers.helpshift.com/rest-api/scenarios/#pagination-and-the-api
> A request would be considered as invalid if the multiplication of `page` and `page-size` parameters is greater than 50,000.

Ran this tap locally and no more errors like:
```
aiohttp.client_exceptions.ClientResponseError: 400, message='Bad Request', url=URL('https://api.helpshift.com/v1/<org>/issues?includes=%5B%22custom_fields%22,+%22meta%22%5D&updated_since=<timestamp>&sort-order=asc&page-size=1000&page=51')
```