### PR TITLE
Add a secondary syncer through the config that doesn't use bookmarks

### DIFF
--- a/tap_helpshift/__init__.py
+++ b/tap_helpshift/__init__.py
@@ -96,8 +96,8 @@ class SyncApplication:
         # To keep issue_analytics up to date, we have a secondary tap running that syncs
         # from the beginning of num_days_to_sync ago till now only for issues and issue_analytics.
         # This window can be fairly large so long as it's during non-busy hours
-        num_days_to_sync = config.get('num_days_to_sync')
-        if self.is_secondary_syncer and num_days_to_sync is not None:
+        if self.is_secondary_syncer:
+            num_days_to_sync = config.get('num_days_to_sync', 7)
             now = datetime.now().replace(tzinfo=timezone.utc, hour=0, minute=0, second=0)
             to_start_syncing_from = now - timedelta(days=num_days_to_sync)
             timestamp = to_start_syncing_from.timestamp()

--- a/tap_helpshift/streams.py
+++ b/tap_helpshift/streams.py
@@ -36,7 +36,7 @@ class Stream():
     datetime_fields = None
     date_format = None
 
-    def __init__(self, client=None, start_date=None, sync_stream_bg=None):
+    def __init__(self, client=None, start_date=None, sync_stream_bg=None, use_bookmarks=True):
         self.client = client
         if start_date:
             self.start_date_int = start_date
@@ -47,11 +47,14 @@ class Stream():
             self.start_date_int = int(self.start_date.strftime('%s')) * 1000
 
         self.sync_stream_bg = sync_stream_bg
+        self.use_bookmarks = use_bookmarks
 
     def is_selected(self):
         return self.stream is not None
 
     def update_bookmark(self, state, value):
+        if not self.use_bookmarks:
+            return
         current_bookmark = singer.get_bookmark(state, self.name, self.replication_key)
         if value and iso_format(value) > iso_format(current_bookmark):
             singer.write_bookmark(state, self.name, self.replication_key, value)

--- a/tap_helpshift/sync.py
+++ b/tap_helpshift/sync.py
@@ -13,7 +13,7 @@ async def sync_stream(state, instance, counter, *args, start_date=None):
     LOGGER.info("%s: Starting sync", stream_name)
 
     # If we have a bookmark, use it; otherwise use start_date & update bookmark with it
-    if (instance.replication_method == 'INCREMENTAL' and
+    if (instance.use_bookmarks and instance.replication_method == 'INCREMENTAL' and
             not state.get('bookmarks', {}).get(stream.tap_stream_id, {}).get(instance.replication_key)):
         singer.write_bookmark(
             state,


### PR DESCRIPTION
Reason is because we're missing updated records due to bookmarks strictly increasing (an issue gets created say Jan 01 then feedback is given on Jan 05 and no longer updated, the bookmark updated time is past Jan 05 -> misses this record).

To be more careful, we're going to add a secondary syncer that will check for `is_secondary_syncer` and `num_days_to_sync` in the config. This will not write any bookmarks for issues and issue analytics.