### PR TITLE
Add end dates with updated_until and more logging

### DIFF
--- a/tap_helpshift/client.py
+++ b/tap_helpshift/client.py
@@ -257,7 +257,7 @@ class HelpshiftAPI:
             # order, we can start a new request at page 1 using the last
             # updated_at time we saw.
             if next_page > MAX_NUM_RESULTS / get_args['page-size']:
-                LOGGER.info(f'helpshift query exceeded {next_page-1} pages, starting loop over')
+                LOGGER.info(f'helpshift query exceeded {next_page-1} pages, starting loop over with new updated_since time: {max_synced}.')
                 next_page = 1
                 get_args['updated_since'] = max_synced
 
@@ -276,6 +276,7 @@ class HelpshiftAPI:
                 'page': next_page,
                 'results_key': results_key,
                 'url': url,
+                'get_args': get_args,
                 'total_returned': total_returned
             })
 
@@ -290,6 +291,7 @@ class HelpshiftAPI:
         LOGGER.info('helpshift paging request complete: %r', {
             'results_key': results_key,
             'last_url': url,
+            'last_get_args': get_args,
             'total_returned': total_returned
         })
 

--- a/tap_helpshift/streams.py
+++ b/tap_helpshift/streams.py
@@ -50,7 +50,7 @@ class Stream():
             self.end_date = datetime.datetime.fromtimestamp(end_date / 1000)
             self.end_date_int = end_date
         else:
-            self.end_date = 0
+            self.end_date = None
             self.end_date_int = 0
 
         self.sync_stream_bg = sync_stream_bg


### PR DESCRIPTION
Allows adding end dates through the config. If there's no end date or the end date is after the start date, we don't pass in the `updated_until` query param (sync all), otherwise sync up till the end date.

Also adds more logging of args.