### PR TITLE
INF-112: add a default timeout for get requests

### DIFF
--- a/tap_helpshift/client.py
+++ b/tap_helpshift/client.py
@@ -139,7 +139,7 @@ class HelpshiftAPI:
             self.running.set()
             LOGGER.info('Requests unpaused')
 
-    async def get(self, get_type, url, params=None, timeout=None):
+    async def get(self, get_type, url, params=None, timeout=DEFAULT_TIMEOUT):
         if not url.startswith('https://'):
             if get_type == GetType.BASIC:
                 url = f'{self.base_url}/{url}'
@@ -266,7 +266,7 @@ class HelpshiftAPI:
             get_args['page'] = next_page
 
             page_url = set_query_parameters(url, **get_args)
-            data = await self.get(GetType.BASIC, page_url, timeout=DEFAULT_TIMEOUT)
+            data = await self.get(GetType.BASIC, page_url)
             if not data:
                 raise RuntimeError(f'No response for {page_url}')
 
@@ -352,7 +352,7 @@ class HelpshiftAPI:
                     **get_args
                 )
 
-                data = await self.get(GetType.ANALYTICS, url, timeout=DEFAULT_TIMEOUT)
+                data = await self.get(GetType.ANALYTICS, url)
                 if not data:
                     break
                 results = data.get('results')

--- a/tap_helpshift/client.py
+++ b/tap_helpshift/client.py
@@ -164,7 +164,7 @@ class HelpshiftAPI:
                 wait_s = 0
 
                 try:
-                    LOGGER.info('GET %s %r', url, params)
+                    LOGGER.info('GET %s %r timeout=%s', url, params, timeout)
                     async with self.session.get(url, params=params, timeout=timeout) as resp:
                         if resp.status >= 200:
                             status = resp.status


### PR DESCRIPTION
Uses environment variable 'DEFAULT_HTTP_TIMEOUT' as defined in the Dockerfile for lloyd (https://github.com/Pathlight/lloyd/pull/68).

Tested by running tap locally using tap config for scopely and hard coding timeout to be 10.

https://user-images.githubusercontent.com/29642644/191628399-cbacbf66-212b-4b63-ad50-57f62edce179.mov

<img width="828" alt="Screen Shot 2022-09-21 at 4 27 44 PM" src="https://user-images.githubusercontent.com/29642644/191628447-c7b2f6ff-fead-4901-b54d-4edc994b56b4.png">
