### PR TITLE
INF-112: Cast environment variable to int before passing in as parameter

### DIFF
--- a/tap_helpshift/client.py
+++ b/tap_helpshift/client.py
@@ -16,7 +16,11 @@ import dateutil.parser
 
 LOGGER = singer.get_logger()
 
-DEFAULT_TIMEOUT = os.getenv('DEFAULT_HTTP_TIMEOUT')
+timeout = os.getenv('DEFAULT_HTTP_TIMEOUT')
+try:
+    DEFAULT_TIMEOUT = int(timeout) if timeout else None
+except (TypeError, ValueError): # casting int can fail depending on the input
+    DEFAULT_TIMEOUT = None
 
 def set_query_parameters(url, **params):
     """Given a URL, set or replace a query parameter and return the
@@ -164,8 +168,8 @@ class HelpshiftAPI:
                 wait_s = 0
 
                 try:
-                    LOGGER.info('GET %s %r timeout=%s', url, params, timeout)
-                    async with self.session.get(url, params=params, timeout=(timeout and int(timeout))) as resp:
+                    LOGGER.info('GET %s %r timeout=%s', url, params, str(timeout))
+                    async with self.session.get(url, params=params, timeout=(timeout)) as resp:
                         if resp.status >= 200:
                             status = resp.status
                         if not status or status >= 400:

--- a/tap_helpshift/client.py
+++ b/tap_helpshift/client.py
@@ -16,7 +16,7 @@ import dateutil.parser
 
 LOGGER = singer.get_logger()
 
-DEFAULT_TIMEOUT = os.getenv('DEFAULT_HTTP_TIMEOUT') or '10'
+DEFAULT_TIMEOUT = os.getenv('DEFAULT_HTTP_TIMEOUT')
 
 def set_query_parameters(url, **params):
     """Given a URL, set or replace a query parameter and return the

--- a/tap_helpshift/client.py
+++ b/tap_helpshift/client.py
@@ -16,7 +16,7 @@ import dateutil.parser
 
 LOGGER = singer.get_logger()
 
-DEFAULT_TIMEOUT = os.getenv('DEFAULT_HTTP_TIMEOUT')
+DEFAULT_TIMEOUT = os.getenv('DEFAULT_HTTP_TIMEOUT') or '10'
 
 def set_query_parameters(url, **params):
     """Given a URL, set or replace a query parameter and return the
@@ -165,7 +165,7 @@ class HelpshiftAPI:
 
                 try:
                     LOGGER.info('GET %s %r timeout=%s', url, params, timeout)
-                    async with self.session.get(url, params=params, timeout=timeout) as resp:
+                    async with self.session.get(url, params=params, timeout=(timeout and int(timeout))) as resp:
                         if resp.status >= 200:
                             status = resp.status
                         if not status or status >= 400:


### PR DESCRIPTION
Follow-up from: https://github.com/Pathlight/tap-helpshift/pull/10/files

Environment variables are stored as strings. As such, when we retrieve the default timeout environment variable, it is a string (or None if the var is not defined). Previously, we were passing the string in directly as the timeout param in the http requests. This resulted in type error (see screenshot below) within the tap.

This PR casts the timeout as an int prior to passing it in as a parameter to the http requests.

 

https://user-images.githubusercontent.com/29642644/192600104-4578c263-f90a-4314-b77e-85a7e7668979.mov


<img width="1252" alt="Screen Shot 2022-09-27 at 9 50 15 AM" src="https://user-images.githubusercontent.com/29642644/192600181-9f48150a-8e27-4087-9e1a-1c4e8f31aaa7.png">

