### PR TITLE
Use config timeout if defined otherwise DEFAULT_TIMEOUT

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-helpshift",
-    version="1.2.29",
+    version="1.2.30",
     description="Singer.io tap for extracting data",
     author="Stitch",
     url="http://singer.io",

--- a/tap_helpshift/__init__.py
+++ b/tap_helpshift/__init__.py
@@ -19,11 +19,11 @@ import singer.metrics as metrics
 from tap_helpshift.client import HelpshiftAPI
 from tap_helpshift.streams import STREAMS, SUB_STREAMS
 from tap_helpshift.sync import sync_stream
-from tap_helpshift.util import consume_q
+from tap_helpshift.util import consume_q, get_logger
 
 
 REQUIRED_CONFIG_KEYS = ["start_date", "api_key", "subdomain"]
-LOGGER = singer.get_logger()
+LOGGER = get_logger()
 
 
 def get_abs_path(path):

--- a/tap_helpshift/client.py
+++ b/tap_helpshift/client.py
@@ -12,9 +12,10 @@ import os
 import aiohttp
 import singer
 import dateutil.parser
+from tap_helpshift.util import get_logger
 
 
-LOGGER = singer.get_logger()
+LOGGER = get_logger()
 
 timeout = os.getenv('DEFAULT_HTTP_TIMEOUT')
 try:
@@ -223,9 +224,8 @@ class HelpshiftAPI:
                     elif isinstance(exc, asyncio.TimeoutError):
                         # Retry on timeout
                         LOGGER.info(
-                            f'api query helpshift error {status}: {exc}', extra={
-                                'url': url
-                            }
+                            f'api query helpshift timeout error {status}: {exc}',
+                            extra={'url': url}
                         )
 
                     elif isinstance(exc, (aiohttp.client_exceptions.ServerDisconnectedError, aiohttp.client_exceptions.ClientConnectionError, RuntimeError)):

--- a/tap_helpshift/client.py
+++ b/tap_helpshift/client.py
@@ -135,7 +135,10 @@ class HelpshiftAPI:
         if DEFAULT_TIMEOUT is not None:
             self.timeout = max(config_timeout or 0, DEFAULT_TIMEOUT)
         else:
+            if config_timeout is not None and config_timeout <= 0:
+                raise ValueError('Timeout cannot be set to a value less than or equal to 0.')
             self.timeout = config_timeout
+        # Because we're using aiohttp, the default timeout is set to 5 minutes if self.timeout is None
 
     async def global_pause(self, seconds):
         if self.running.is_set():

--- a/tap_helpshift/streams.py
+++ b/tap_helpshift/streams.py
@@ -7,10 +7,10 @@ import queue
 from singer.utils import strftime as singer_strftime
 import singer
 
-from .util import consume_q
+from .util import consume_q, get_logger
 from .sync import sync_stream
 
-LOGGER = singer.get_logger()
+LOGGER = get_logger()
 
 SUB_STREAMS = {
     'issues': ['messages']

--- a/tap_helpshift/sync.py
+++ b/tap_helpshift/sync.py
@@ -1,8 +1,9 @@
 import singer
 from singer import metadata
+from tap_helpshift.util import get_logger
 
 
-LOGGER = singer.get_logger()
+LOGGER = get_logger()
 
 
 async def sync_stream(state, instance, counter, *args, start_date=None):

--- a/tap_helpshift/util.py
+++ b/tap_helpshift/util.py
@@ -1,4 +1,6 @@
 import queue
+import logging
+import singer
 
 
 def consume_q(q):
@@ -7,3 +9,28 @@ def consume_q(q):
             yield q.get_nowait()
         except queue.Empty:
             return
+
+class TapLoggerAdapter(logging.LoggerAdapter):
+    """
+    TapLoggerAdapter is a subclass of LoggerAdapter that:
+
+    1. Merges in `extra` props passed by the user to the final `extra` props
+       (LoggerAdapter simply ignores any `extra` passed into its log methods)
+    2. If we are wrapping another LoggerAdapter, TapLoggerAdapter will merge
+       the `extra` objects of both into the final output (LoggerAdapter only
+       uses the wrapped adapter's `extra`)
+    """
+    def __init__(self, logger, extra=None):
+        super().__init__(logger, extra)
+
+    def process(self, msg, kwargs):
+        extra = kwargs.pop('extra', {})
+        msg, kwargs = super().process(msg, kwargs)
+        if isinstance(self.logger, logging.LoggerAdapter):
+            msg, kwargs = self.logger.process(msg, kwargs)
+        kwargs['extra'] = {**kwargs['extra'], **extra}
+        formatted_msg = ', '.join([msg] + [f'{k}={v}' for k, v in kwargs['extra'].items()])
+        return formatted_msg, kwargs
+
+def get_logger(extra=None):
+    return TapLoggerAdapter(singer.get_logger(), extra)


### PR DESCRIPTION
Also logs out the 'extra' kwarg passed into each of the log methods. Previously we were not including this information, so logs looked a little empty. Example: https://splunk.pathlight.com/en-GB/app/search/search?q=search%20%22no%20end_date%20or%20end_date%20after%20start_date%2C%20syncing%20up%20till%20now%22&sid=1666646878.13406919&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-24h%40h&latest=now