### PR TITLE
Fix issues bookmark value conversion

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-helpshift",
-    version="1.2.34",
+    version="1.2.35",
     description="Singer.io tap for extracting data",
     author="Stitch",
     url="http://singer.io",

--- a/tap_helpshift/streams.py
+++ b/tap_helpshift/streams.py
@@ -90,9 +90,11 @@ class Issues(Stream):
 
     async def sync(self, state):
         try:
-            sync_thru = datetime_to_epoch_seconds(singer.get_bookmark(
-                state, self.name, self.replication_key
-            )) or self.start_date_epoch_milliseconds
+            singer_bookmark_value = singer.get_bookmark(state, self.name, self.replication_key)
+            # If the singer_bookmark_value is not a string, it'll get caught as a TypeError
+            singer_bookmark_datetime: 'datetime.datetime' = parse_datetime(singer_bookmark_value)
+            singer_bookmark_epoch_milliseconds = datetime_to_epoch_seconds(singer_bookmark_datetime) * 1000
+            sync_thru = singer_bookmark_epoch_milliseconds or self.start_date_epoch_milliseconds
         except TypeError:
             sync_thru = self.start_date_epoch_milliseconds
 


### PR DESCRIPTION
The singer bookmark is:
1. string if it exists, does the proper calculation in epoch milliseconds
2. datetime if it doesn't, gets caught as TypeError with parse_datetime